### PR TITLE
Extend lab-d with full bi-directional excerice

### DIFF
--- a/advanced-compositions/lab-d/composition.yaml
+++ b/advanced-compositions/lab-d/composition.yaml
@@ -15,8 +15,8 @@ spec:
         - fromFieldPath: spec.id
           toFieldPath: spec.id
         - type: ToCompositeFieldPath
-          fromFieldPath: # Fill in with XNetwork status path
-          toFieldPath: # Fill in with XCluster status path
+          fromFieldPath: # Fill in with XNetwork status path for subnetIds
+          toFieldPath: # Fill in with XCluster status path to keep subnetIds
           policy:
             fromFieldPath: Required
         - type: ToCompositeFieldPath

--- a/advanced-compositions/lab-d/composition.yaml
+++ b/advanced-compositions/lab-d/composition.yaml
@@ -10,13 +10,13 @@ spec:
   resources:
     - base:
         apiVersion: # Fill in the custom platform API Group
-        kind: # Fill in the Xnetwork kind
+        kind: # Fill in the XNetwork kind
       patches:
         - fromFieldPath: spec.id
           toFieldPath: spec.id
         - type: ToCompositeFieldPath
-          fromFieldPath: status.subnetIds
-          toFieldPath: status.subnetIds
+          fromFieldPath: # Fill in with XNetwork status path
+          toFieldPath: # Fill in with XCluster status path
           policy:
             fromFieldPath: Required
         - type: ToCompositeFieldPath
@@ -48,8 +48,8 @@ spec:
           toFieldPath: spec.parameters.nodes.count
         - fromFieldPath: spec.parameters.nodes.size
           toFieldPath: spec.parameters.nodes.size
-        - fromFieldPath: status.subnetIds
-          toFieldPath: spec.parameters.subnetIds
+        - fromFieldPath: # Fill in the XCluster status path that keeps the subnetIds
+          toFieldPath: # Fill in the XEKS spec for subnetIds
           policy:
             fromFieldPath: Required
         - fromFieldPath: status.securityGroupIds


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->
Make lab-d a little bit more challening with the ask to fill in the values for bi-directional patch

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
