### PR TITLE
Fix lab progression issues

### DIFF
--- a/advanced-compositions/lab-a/composition.yaml
+++ b/advanced-compositions/lab-a/composition.yaml
@@ -9,7 +9,7 @@ spec:
   compositeTypeRef:
     apiVersion: aws.platformref.upbound.io/v1alpha1
     kind: XNetwork
- 
+
    # patchSets contain patches that can be shared among managed resources
   patchSets:
   - name: network-id
@@ -23,19 +23,19 @@ spec:
     # Every resource in a composition should have three items defined:
     #    - base: contains the Managed Resource
     #      name: name of the resource to identity it. Recommended
-    #      patches: patches to apply to the managed resource. 
+    #      patches: patches to apply to the managed resource.
     - base:
         apiVersion: ec2.aws.upbound.io/v1beta1
         kind: VPC
         spec:
           forProvider:
-            region: us-west-2
+            region: eu-west-1
             cidrBlock: 192.168.0.0/16
-# Add missing fields to configure DNS for this VPC   
+# Add missing fields to configure DNS for this VPC
             tags:
               Owner: Platform Team
               Name: platformref-vpc
       name: platformref-vpc
-      patches: 
+      patches:
         - type: PatchSet
           patchSetName: network-id

--- a/advanced-compositions/lab-b/composition.yaml
+++ b/advanced-compositions/lab-b/composition.yaml
@@ -39,8 +39,8 @@ spec:
           forProvider:
             region: eu-west-1
             #
-            # The InternetGateway requires a VPC. 
-            # How do we refer to the VPC defined above? 
+            # The InternetGateway requires a VPC.
+            # How do we refer to the VPC defined above?
       name: gateway
       patches:
         - type: PatchSet

--- a/advanced-compositions/lab-b/definition.yaml
+++ b/advanced-compositions/lab-b/definition.yaml
@@ -26,10 +26,6 @@ spec:
             status:
               type: object
               properties:
-                subnetIds:
-                  type: array
-                  items:
-                    type: string
                 securityGroupIds:
                   type: array
                   items:

--- a/advanced-compositions/lab-base/composition.yaml
+++ b/advanced-compositions/lab-base/composition.yaml
@@ -2,17 +2,17 @@ apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
 
-  name: example
+  name: xnetworks.aws.platformref.upbound.io
 
   labels:
     # An optional convention is to include a label of the XRD. This allows
     # easy discovery of compatible Compositions.
 
-    crossplane.io/xrd: xpostgresqlinstances.database.example.org
+    crossplane.io/xrd: xnetworks.platformref.upbound.io
 
-    # The following label marks this Composition for GCP. This label can
+    # The following label marks this Composition for AWS. This label can
     # be used in 'compositionSelector' in an XR or Claim.
-    provider: gcp
+    provider: aws
 
     # Other labels can be added to match.
 spec:
@@ -22,9 +22,9 @@ spec:
   # version must be marked 'referenceable' in the XRD that defines the XR.
 
   # Multiple Compositions can refer to the same Composite Resource.
- compositeTypeRef:
-    apiVersion: database.example.org/v1alpha1
-    kind: XPostgreSQLInstance
+  compositeTypeRef:
+     apiVersion: aws.platformref.upbound.io/v1alpha1
+     kind: XNetwork
 
   # When an XR is created in response to a claim Crossplane needs to know where
   # it should create the XR's connection secret. This is configured using the
@@ -32,16 +32,18 @@ spec:
 
   # Upbound's UXP usually uses the  upbound-system namespace.
   # CNCF Crossplane is installed to the crossplane-system namespace.
-
   writeConnectionSecretsToNamespace: upbound-system
 
   # Each Composition must specify at least one composed resource template. In
   # this case the Composition tells Crossplane that it should create, update, or
-  # delete a CloudSQLInstance whenever someone creates, updates, or deletes an
-  # XPostgresSQLInstance.
+  # delete a VPC whenever someone creates, updates, or deletes an
+  # XNetwork
 
   # The next section is a list of resources that is part of the composition.
   # We'll be filling these in during the next labs.
 
   resources:
-  - name: toBeDefined
+    - name: vpc
+      base:
+        apiVersion: ec2.aws.upbound.io/v1beta1
+        kind: VPC

--- a/advanced-compositions/lab-base/definition.yaml
+++ b/advanced-compositions/lab-base/definition.yaml
@@ -2,27 +2,27 @@ apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
   # XRDs must be named '<plural>.<group>', per the plural and group names below.
-  name: xpostgresqlinstances.example.org
+  name: xnetworks.aws.platformref.upbound.io
 spec:
 
-  # This XRD defines an XR in the 'example.org' API group.
+  # This XRD defines an XR in the 'aws.platformref.upbound.io' API group.
 
-  group: example.org
-  # The kind of this XR will be 'XPostgreSQLInstance`. You may also optionally
+  group: aws.platformref.upbound.io
+  # The kind of this XR will be 'XNetwork`. You may also optionally
   # specify a singular name and a listKind.
   names:
-    kind: XPostgreSQLInstance
-    plural: xpostgresqlinstances
+    kind: XNetwork
+    plural: xnetworks
 
   # This type of XR offers a claim. Omit claimNames if you don't want to do so.
   # The claimNames must be different from the names above - a common convention
   # is that names are prefixed with 'X' while claim names are not. This lets app
   # team members think of creating a claim as (e.g.) 'creating a
-  # PostgreSQLInstance'.
+  # Network'.
 
   claimNames:
-    kind: PostgreSQLInstance
-    plural: postgresqlinstances
+    kind: Network
+    plural: networks
 
   # Each type of XR can declare any keys they write to their connection secret
   # which will act as a filter during aggregation of the connection secret from
@@ -63,24 +63,22 @@ spec:
     # determines what fields your XR and claim will have. Note that Crossplane
     # will automatically extend with some additional Crossplane machinery.
     schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              parameters:
-                type: object
-                properties:
-                  storageGB:
-                    type: integer
-                required:
-                - storageGB
-            required:
-            - parameters
-          status:
-            type: object
-            properties:
-              address:
-                description: Address of this PostgreSQL server.
-                type: string
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                id:
+                  type: string
+                  description: ID of this Network that other objects will use to refer to it.
+              required:
+                - id
+            status:
+              type: object
+              properties:
+                securityGroupIds:
+                  description: custom status field of array type
+                  type: array
+                  items:
+                    type: string


### PR DESCRIPTION

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

* Align VPC region between lab-a and lab-b, otherwise it will break the flow in case in-place Composition update
* Remove custom `status.subnetIds` definition before the lab-c, to not confuse people with `unchanged` feedback after implementing the task and `kubectl apply` right after the lab-b
* Change lab-base to demonstrate XNetwork not XPosrgresqlInstance to create a natural XNetwork enhancement progression from the base up to the next labs where lab-{a,b,c} are focusing purely on XNetwork
* Occasional whitespace busting

Thanks to @bmutziu for the great feedback on the training session

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

with `kubectl apply` of associated manifests