### PR TITLE
fix(vpc-selector): fix issue with vpcSecurityGroupI(D:)Selector

### DIFF
--- a/lab05/configuration/composition.yaml
+++ b/lab05/configuration/composition.yaml
@@ -174,7 +174,7 @@ spec:
             region: us-east-1
             dbSubnetGroupNameSelector:
               matchControllerRef: true
-            vpcSecurityGroupIDSelector:
+            vpcSecurityGroupIdSelector:
               matchControllerRef: true
             instanceClass: db.t2.small
             username: masteruser

--- a/lab06-transform-patch/configuration/composition.yaml
+++ b/lab06-transform-patch/configuration/composition.yaml
@@ -173,7 +173,7 @@ spec:
             region: us-east-1
             dbSubnetGroupNameSelector:
               matchControllerRef: true
-            vpcSecurityGroupIDSelector:
+            vpcSecurityGroupIdSelector:
               matchControllerRef: true
             instanceClass: db.t2.small
             username: masteruser

--- a/lab07-xrd-status/configuration/composition.yaml
+++ b/lab07-xrd-status/configuration/composition.yaml
@@ -173,7 +173,7 @@ spec:
             region: us-east-1
             dbSubnetGroupNameSelector:
               matchControllerRef: true
-            vpcSecurityGroupIDSelector:
+            vpcSecurityGroupIdSelector:
               matchControllerRef: true
             instanceClass: db.t2.small
             username: masteruser

--- a/lab08/aws/composition.yaml
+++ b/lab08/aws/composition.yaml
@@ -174,7 +174,7 @@ spec:
             region: us-east-1
             dbSubnetGroupNameSelector:
               matchControllerRef: true
-            vpcSecurityGroupIDSelector:
+            vpcSecurityGroupIdSelector:
               matchControllerRef: true
             instanceClass: db.t2.small
             username: masteruser


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
https://marketplace.upbound.io/providers/upbound/provider-aws-rds/v0.41.0/resources/rds.aws.upbound.io/Instance/v1beta1#doc:spec-forProvider-vpcSecurityGroupIdSelector

switch vpcSecurityGroupIDSelector to vpcSecurityGroupIdSelector

The issue lies in the fact that the provider can create an RDS instance without specifying the vpcSecurityGroupIdSelector, as long as a default security group is present. However, if there is no default security group in the VPC, you will encounter an error indicating that the RDS creation failed due to the absence of an EC2 security group.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
