### PR TITLE
applyImmediately for RDS Instance Composition examples

### DIFF
--- a/lab05/configuration/composition.yaml
+++ b/lab05/configuration/composition.yaml
@@ -171,6 +171,7 @@ spec:
         kind: Instance
         spec:
           forProvider:
+            applyImmediately: true # apply changes immediately instead of waiting for the standard RDS maintenance window
             region: us-east-1
             dbSubnetGroupNameSelector:
               matchControllerRef: true

--- a/lab06-transform-patch/configuration/composition.yaml
+++ b/lab06-transform-patch/configuration/composition.yaml
@@ -171,6 +171,7 @@ spec:
         kind: Instance
         spec:
           forProvider:
+            applyImmediately: true # apply changes immediately instead of waiting for the standard RDS maintenance window
             region: us-east-1
             dbSubnetGroupNameSelector:
               matchControllerRef: true


### PR DESCRIPTION

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

* Use https://marketplace.upbound.io/providers/upbound/provider-aws-rds/v0.41.0/resources/rds.aws.upbound.io/Instance/v1beta1#doc:spec-forProvider-applyImmediately to avoid waiting for the default RDS maintenance window
* It is to avoid confusion during the training and avoid creating impression that the instance is not getting updated, attendees are naturally playing with instanceClass modification in lab06


I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Instantiate claim from lab06, wait for ready=true, update class, apply

```
diff --git a/lab06-transform-patch/claim.yaml b/lab06-transform-patch/claim.yaml
index 15cb8dc..60104d4 100644
--- a/lab06-transform-patch/claim.yaml
+++ b/lab06-transform-patch/claim.yaml
@@ -1,13 +1,13 @@
 apiVersion: database.example.org/v1alpha1
 kind: PostgreSQLInstance
 metadata:
-  name: my-db
+  name: my-db-immediate
   namespace: default
 spec:
   parameters:
     storageGB: 20
     passwordSecretName: getting-started-db-pass
-    class: small # small, medium, large
+    class: medium # small, medium, large
   compositionSelector:
     matchLabels:
       uxp-guide: getting-started
```

Observe in AWS console that instance went to `Modifying` state immediately after the spec update. 
Wait for the full eventuall consistency between `spec.forProvider.instanceClass` and `spec.atProvider.instanceClass`
of  associated `Instance.rds.aws.upbound.io/v1beta1` 



