### PR TITLE
Extend lab-d with the provider dependency and e2e claim

### DIFF
--- a/advanced-compositions/lab-d-solution/cluster-claim.yaml
+++ b/advanced-compositions/lab-d-solution/cluster-claim.yaml
@@ -1,0 +1,16 @@
+apiVersion: aws.platformref.upbound.io/v1alpha1
+kind: Cluster
+metadata:
+  name: platform-ref-aws
+spec:
+  id: platform-ref-aws
+  parameters:
+    nodes:
+      count: 3
+      size: small
+    services:
+      operators:
+        prometheus:
+          version: "34.5.1"
+  writeConnectionSecretToRef:
+    name: platform-ref-aws-kubeconfig

--- a/advanced-compositions/lab-d-solution/providers.yaml
+++ b/advanced-compositions/lab-d-solution/providers.yaml
@@ -4,6 +4,8 @@ metadata:
   name: provider-aws-iam
 spec:
   package: xpkg.upbound.io/upbound/provider-aws-iam:v0.42.0
+  controllerConfigRef:
+    name: op-aws-config
 ---
 apiVersion: pkg.crossplane.io/v1
 kind: Provider

--- a/advanced-compositions/lab-d-solution/providers.yaml
+++ b/advanced-compositions/lab-d-solution/providers.yaml
@@ -1,0 +1,34 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-aws-iam
+spec:
+  package: xpkg.upbound.io/upbound/provider-aws-iam:v0.42.0
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-aws-ec2
+spec:
+  package: xpkg.upbound.io/upbound/provider-aws-ec2:v0.42.0
+  controllerConfigRef:
+    name: op-aws-config
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-aws-eks
+spec:
+  package: xpkg.upbound.io/upbound/provider-aws-eks:v0.42.0
+  controllerConfigRef:
+    name: op-aws-config
+---
+apiVersion: pkg.crossplane.io/v1alpha1
+kind: ControllerConfig
+metadata:
+  name: op-aws-config
+  labels:
+    app: provider-aws
+spec:
+  args:
+    - -d

--- a/advanced-compositions/lab-d/cluster-claim.yaml
+++ b/advanced-compositions/lab-d/cluster-claim.yaml
@@ -1,0 +1,16 @@
+apiVersion: aws.platformref.upbound.io/v1alpha1
+kind: Cluster
+metadata:
+  name: platform-ref-aws
+spec:
+  id: platform-ref-aws
+  parameters:
+    nodes:
+      count: 3
+      size: small
+    services:
+      operators:
+        prometheus:
+          version: "34.5.1"
+  writeConnectionSecretToRef:
+    name: platform-ref-aws-kubeconfig

--- a/advanced-compositions/lab-d/providers.yaml
+++ b/advanced-compositions/lab-d/providers.yaml
@@ -4,6 +4,8 @@ metadata:
   name: provider-aws-iam
 spec:
   package: xpkg.upbound.io/upbound/provider-aws-iam:v0.42.0
+  controllerConfigRef:
+    name: op-aws-config
 ---
 apiVersion: pkg.crossplane.io/v1
 kind: Provider

--- a/advanced-compositions/lab-d/providers.yaml
+++ b/advanced-compositions/lab-d/providers.yaml
@@ -1,0 +1,34 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-aws-iam
+spec:
+  package: xpkg.upbound.io/upbound/provider-aws-iam:v0.42.0
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-aws-ec2
+spec:
+  package: xpkg.upbound.io/upbound/provider-aws-ec2:v0.42.0
+  controllerConfigRef:
+    name: op-aws-config
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-aws-eks
+spec:
+  package: xpkg.upbound.io/upbound/provider-aws-eks:v0.42.0
+  controllerConfigRef:
+    name: op-aws-config
+---
+apiVersion: pkg.crossplane.io/v1alpha1
+kind: ControllerConfig
+metadata:
+  name: op-aws-config
+  labels:
+    app: provider-aws
+spec:
+  args:
+    - -d


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Extend lab-d with the provider dependency and e2e claim

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```
k get claim
NAME                                                  SYNCED   READY   CONNECTION-SECRET             AGE
cluster.aws.platformref.upbound.io/platform-ref-aws   True     True    platform-ref-aws-kubeconfig   38m
```
