### PR TITLE
Add `fromFieldPath: Required` to Policy in lab07

### DIFF
--- a/lab07-xrd-status/configuration/composition.yaml
+++ b/lab07-xrd-status/configuration/composition.yaml
@@ -223,6 +223,8 @@ spec:
       patches:
         - fromFieldPath: "status.instance.arn"
           toFieldPath: "spec.forProvider.policy"
+          policy:
+            fromFieldPath: Required
           transforms:
             - type: string
               string:


### PR DESCRIPTION
* `fromFieldPath: Required` will guard incorrect instantiation of Policy resource
* It also can serve as good contextual example of using the `policy` within for reliable bi-directional patching

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
